### PR TITLE
Change access and publish property names

### DIFF
--- a/templates/default/config.yaml.erb
+++ b/templates/default/config.yaml.erb
@@ -30,21 +30,21 @@ packages:
   '<%= filter['name'] %>':
   <% if filter['access'] %>
     <% if filter['access'] == '@admins' %>
-    allow_access: admin <%= @admins.join(' ') %>
+    access: admin <%= @admins.join(' ') %>
     <% else %>
-    allow_access: admin <%= filter['access'].join(' ') %>
+    access: admin <%= filter['access'].join(' ') %>
     <% end %>
   <% else %>
-    allow_access: $all
+    access: $all
   <% end %>
   <% if filter['publish'] %>
     <% if filter['publish'] == '@admins' %>
-    allow_publish: admin <%= @admins.join(' ') %>
+    publish: admin <%= @admins.join(' ') %>
     <% else %>
-    allow_publish: admin <%= filter['access'].join(' ') %>
+    publish: admin <%= filter['access'].join(' ') %>
     <% end %>
   <% else %>
-    allow_publish: admin
+    publish: admin
   <% end %>
   <% if filter['storage'] %>
     storage: <%= filter['storage'] %>
@@ -57,11 +57,11 @@ packages:
 <%- if !wildcard_is_defined -%>
   '*':
   <% if node['sinopia']['strict_access'] %>
-    allow_access: admin <%= @admins.join(' ') %>
+    access: admin <%= @admins.join(' ') %>
   <% else %>
-    allow_access: $all
+    access: $all
   <% end %>
-    allow_publish: admin <%= @admins.join(' ') %>
+    publish: admin <%= @admins.join(' ') %>
     proxy: <%= node['sinopia']['mainrepo'] %>
 <%- end -%>
 


### PR DESCRIPTION
Sinopia changed the name or `allo_access` to `access` and
`allow_publish` to `publish` in
https://github.com/rlidwka/sinopia/commit/3c16e59a5c5551a372910631636a3c82878ab0df.

This modifies the names to match the change.
